### PR TITLE
remove royalty loop

### DIFF
--- a/contracts/exchange/Erc20Escrow.sol
+++ b/contracts/exchange/Erc20Escrow.sol
@@ -112,20 +112,24 @@ contract Erc20Escrow is IErc20Escrow, EscrowBase {
     
     // Transfer Creator Royalty from escrowed buy order to escrow
     function transferRoyalty(
-        uint256 _orderId,
+        uint256[] calldata _orderIds,
         address _owner,
-        uint256 _amount
+        uint256[] calldata _amounts
     ) external override onlyRole(MANAGER_ROLE) {        
-        require(escrowedByOrder[_orderId].amount >= _amount, "Invalid royalty amount");
+        for (uint256 i = 0; i < _orderIds.length; i++) {
+            if (_amounts[i] > 0) {
+                require(escrowedByOrder[_orderIds[i]].amount >= _amounts[i], "Invalid royalty amount");
 
-        // No need to do checks. The exchange contracts will do the checks.
-        address token = escrowedByOrder[_orderId].token;
-        escrowedByOrder[_orderId].amount = escrowedByOrder[_orderId].amount - _amount;
+                // No need to do checks. The exchange contracts will do the checks.
+                address token = escrowedByOrder[_orderIds[i]].token;
+                escrowedByOrder[_orderIds[i]].amount = escrowedByOrder[_orderIds[i]].amount - _amounts[i];
 
-        if (!claimableByOwner[_owner].contains(token)) {
-            claimableByOwner[_owner].set(token, _amount);
-        } else {
-            claimableByOwner[_owner].set(token, claimableByOwner[_owner].get(token) + _amount);
+                if (!claimableByOwner[_owner].contains(token)) {
+                    claimableByOwner[_owner].set(token, _amounts[i]);
+                } else {
+                    claimableByOwner[_owner].set(token, claimableByOwner[_owner].get(token) + _amounts[i]);
+                }
+            }
         }
     }
 

--- a/contracts/exchange/interfaces/IErc20Escrow.sol
+++ b/contracts/exchange/interfaces/IErc20Escrow.sol
@@ -23,7 +23,11 @@ interface IErc20Escrow {
     
     function transferRoyalty(address _token, address _sender, address _owner, uint256 _amount) external;
 
-    function transferRoyalty(uint256 _orderId, address _to, uint256 _amount) external;
+    function transferRoyalty(
+        uint256[] calldata _orderIds,
+        address _owner,
+        uint256[] calldata _amounts
+    ) external;
     
     function transferPlatformFee(address _token, address _sender, address _feesEscrow, uint256 _amount) external;
 

--- a/contracts/exchange/interfaces/IRoyaltyManager.sol
+++ b/contracts/exchange/interfaces/IRoyaltyManager.sol
@@ -8,10 +8,15 @@ interface IRoyaltyManager {
 
     function claimableRoyalties(address _user) external view returns(address[] memory tokens, uint256[] memory amounts);
 
-    function payableRoyalties(
+    function buyOrderRoyalties(
         LibOrder.AssetData calldata _asset,
-        uint256 _total
-    ) external view returns(address receiver, uint256 fee, uint256 remaining);
+        uint256[] memory amountPerOrder
+    ) external view returns(address receiver, uint256[] memory royaltyFees, uint256[] memory platformFees, uint256[] memory remaining);
+
+    function sellOrderRoyalties(
+        LibOrder.AssetData calldata _asset,
+        uint256[] memory amountPerOrder
+    ) external view returns(address receiver, uint256 royaltyTotal, uint256[] memory remaining);
 
     /******** Mutative Functions ********/
     function claimRoyalties(address _user) external;
@@ -24,12 +29,12 @@ interface IRoyaltyManager {
     ) external;
 
     function transferRoyalty(
-        uint256 _orderId,
+        uint256[] calldata _orderIds,
         address _receiver,
-        uint256 _royaltyFee
+        uint256[] calldata _royaltyFees
     ) external;
 
     function transferPlatformFee(address _sender, address _token, uint256 _total) external;
 
-    function transferPlatformFee(address _token, uint256 _orderId, uint256 _total) external;
+    function transferPlatformFee(address _token, uint256[] calldata _orderIds, uint256[] memory platformFees) external;
 }

--- a/test/exchange/Erc20EscrowTests.js
+++ b/test/exchange/Erc20EscrowTests.js
@@ -52,7 +52,7 @@ describe('ERC20 Escrow Contract tests', () => {
     
         it('Supports the Erc20Escrow Interface', async () => {
             // IErc20Escrow Interface
-            expect(await escrow.supportsInterface("0xc179aeed")).to.equal(true);
+            expect(await escrow.supportsInterface("0xb50e494b")).to.equal(true);
 
             // IEscrowBase Interface
             expect(await escrow.supportsInterface("0xc7aacb62")).to.equal(true);
@@ -190,7 +190,7 @@ describe('ERC20 Escrow Contract tests', () => {
             await rawrToken.connect(playerAddress).approve(escrow.address, tokenAmount);
             await escrow.connect(executionManagerAddress).deposit(rawrToken.address, 1, playerAddress.address, tokenAmount);
 
-            await escrow.connect(executionManagerAddress)['transferRoyalty(uint256,address,uint256)'](1, creatorAddress.address, ethers.BigNumber.from(1000).mul(_1e18));
+            await escrow.connect(executionManagerAddress)['transferRoyalty(uint256[],address,uint256[])']([1], creatorAddress.address, [ethers.BigNumber.from(1000).mul(_1e18)]);
             
             // check escrowed tokens by order (1)
             expect(await escrow.escrowedTokensByOrder(1)).to.equal(ethers.BigNumber.from(4000).mul(_1e18));
@@ -280,7 +280,7 @@ describe('ERC20 Escrow Contract tests', () => {
             await rawrToken.connect(playerAddress).approve(escrow.address, ethers.BigNumber.from(5000).mul(_1e18));
             await escrow.connect(executionManagerAddress).deposit(rawrToken.address, 1, playerAddress.address, ethers.BigNumber.from(5000).mul(_1e18));
     
-            await escrow.connect(executionManagerAddress)['transferRoyalty(uint256,address,uint256)'](1, creatorAddress.address, ethers.BigNumber.from(1000).mul(_1e18));
+            await escrow.connect(executionManagerAddress)['transferRoyalty(uint256[],address,uint256[])']([1], creatorAddress.address, [ethers.BigNumber.from(1000).mul(_1e18)]);
 
             await escrow.connect(executionManagerAddress).withdraw(1, player2Address.address, ethers.BigNumber.from(4000).mul(_1e18));
     


### PR DESCRIPTION
In this PR:
- I removed the loops in fillbuyorder and fillsellorder, so that the royalties and platform fees will be paid out once instead of multiple times for multiple order Ids.
- I added tests for the new functions in RoyaltyManager.sol and for filling multiple buy orders in Exchange.sol