### PR TITLE
reduce platform fee transfers

### DIFF
--- a/contracts/exchange/RoyaltyManager.sol
+++ b/contracts/exchange/RoyaltyManager.sol
@@ -65,13 +65,15 @@ contract RoyaltyManager is IRoyaltyManager, ManagerBase {
         uint256[] calldata _orderIds,
         uint256[] calldata platformFees
     ) external override onlyOwner {
-        for (uint256 i = 0; i < platformFees.length; i++) {    
-            if (_exchangeFeesEscrow().hasExchangeFees()) {
-                // Rate has to be greater than 0 and there must be someone staking. If no one is staking,
-                // we ignore platform fees because no one will be able to collect it.
-                _exchangeFeesEscrow().depositFees(_token, platformFees[i]);
-                _tokenEscrow().transferPlatformFee(_orderIds[i], address(_exchangeFeesEscrow()), platformFees[i]);
+        if (_exchangeFeesEscrow().hasExchangeFees()) {
+            // Rate has to be greater than 0 and there must be someone staking. If no one is staking,
+            // we ignore platform fees because no one will be able to collect it.
+            uint256 totalFee;
+            for (uint256 i = 0; i < platformFees.length; i++) {    
+                totalFee += platformFees[i];
             }
+            _exchangeFeesEscrow().depositFees(_token, totalFee);
+            _tokenEscrow().transferPlatformFee(_orderIds, address(_exchangeFeesEscrow()), platformFees, totalFee);
         }
     }
     

--- a/contracts/exchange/interfaces/IErc20Escrow.sol
+++ b/contracts/exchange/interfaces/IErc20Escrow.sol
@@ -31,7 +31,12 @@ interface IErc20Escrow {
     
     function transferPlatformFee(address _token, address _sender, address _feesEscrow, uint256 _amount) external;
 
-    function transferPlatformFee(uint256 _orderId, address _feesEscrow, uint256 _amount) external;
+    function transferPlatformFee(
+        uint256[] calldata _orderIds, 
+        address _feesEscrow, 
+        uint256[] calldata _platformFees, 
+        uint256 totalFee
+    ) external;
 
     function claimRoyalties(address _owner) external;
 

--- a/test/exchange/Erc20EscrowTests.js
+++ b/test/exchange/Erc20EscrowTests.js
@@ -52,7 +52,7 @@ describe('ERC20 Escrow Contract tests', () => {
     
         it('Supports the Erc20Escrow Interface', async () => {
             // IErc20Escrow Interface
-            expect(await escrow.supportsInterface("0xb50e494b")).to.equal(true);
+            expect(await escrow.supportsInterface("0x3b05caed")).to.equal(true);
 
             // IEscrowBase Interface
             expect(await escrow.supportsInterface("0xc7aacb62")).to.equal(true);
@@ -264,7 +264,7 @@ describe('ERC20 Escrow Contract tests', () => {
             expect(await rawrToken.balanceOf(platformFeesPoolAddress.address)).to.equal(ethers.BigNumber.from(5000).mul(_1e18));
 
             // transfer platform fee
-            await escrow.connect(executionManagerAddress)['transferPlatformFee(uint256,address,uint256)'](1, platformFeesPoolAddress.address, ethers.BigNumber.from(1000).mul(_1e18));
+            await escrow.connect(executionManagerAddress)['transferPlatformFee(uint256[],address,uint256[],uint256)']([1], platformFeesPoolAddress.address, [ethers.BigNumber.from(1000).mul(_1e18)], ethers.BigNumber.from(1000).mul(_1e18));
 
             // check platform fees pool balance
             expect(await rawrToken.balanceOf(platformFeesPoolAddress.address)).to.equal(ethers.BigNumber.from(6000).mul(_1e18));


### PR DESCRIPTION
In this PR:
- I changed transferPlatformFees() so that the total platform fees from the order is paid out only once instead of once each for multiple order Ids. This makes transactions with one order id cost 1.1k more gas but makes transactions with multiple order ids cost 44.1k less gas than it originally cost for each additional order id.