### PR TITLE
reduce transfers in executeBuyOrder

### DIFF
--- a/contracts/exchange/ExecutionManager.sol
+++ b/contracts/exchange/ExecutionManager.sol
@@ -45,16 +45,10 @@ contract ExecutionManager is IExecutionManager, ManagerBase {
         external override onlyOwner
     {
         require(_orderIds.length == _paymentPerOrder.length && _orderIds.length == _amounts.length, "Invalid input length");
-        
-        for (uint256 i = 0; i < _orderIds.length; ++i) {
-            if (_amounts[i] > 0) {
-                // Send Assets to escrow
-                _nftEscrow().deposit(_orderIds[i], _user, _amounts[i], _asset);
-                
-                // send payment from escrow to user
-                _tokenEscrow().withdraw(_orderIds[i], _user, _paymentPerOrder[i]);
-            }
-        }
+        // Send Assets to escrow
+        _nftEscrow().depositBatch(_orderIds, _user, _amounts, _asset);
+        // send payment from escrow to user
+        _tokenEscrow().withdrawBatch(_orderIds, _user, _paymentPerOrder);
     }
 
     // Send assets from escrow to user, send tokens from user to escrow
@@ -67,11 +61,9 @@ contract ExecutionManager is IExecutionManager, ManagerBase {
         external override onlyOwner
     {
         require(_orderIds.length == _paymentPerOrder.length && _orderIds.length == _amounts.length, "Invalid input length");
-        
         // send payment from user to escrow
         _tokenEscrow().depositBatch(_token, _orderIds, _user, _paymentPerOrder);
-
-        // send asset to buyer
+        // send asset from escrow to buyer
         _nftEscrow().withdrawBatch(_orderIds, _user, _amounts);
     }
 

--- a/contracts/exchange/NftEscrow.sol
+++ b/contracts/exchange/NftEscrow.sol
@@ -51,6 +51,25 @@ contract NftEscrow is INftEscrow, EscrowBase, ERC1155HolderUpgradeable, ERC721Ho
         _transfer(_orderId, _sender, address(this), _amount);
     }
 
+    function depositBatch(
+        uint256[] calldata _orderIds,
+        address _sender,
+        uint256[] calldata _amounts,
+        LibOrder.AssetData memory _assetData
+    ) external override onlyRole(MANAGER_ROLE) {
+        uint256 total;
+        for (uint256 i =0; i < _orderIds.length; i++) {
+            if (_amounts[i] > 0) {
+                // Update mappings for each order
+                escrowedAsset[_orderIds[i]] = _assetData;
+                escrowedAmounts[_orderIds[i]] = escrowedAmounts[_orderIds[i]] + _amounts[i];
+                // tally up total amount of assets
+                total += _amounts[i];
+            }
+        }
+        _transfer(_orderIds[0], _sender, address(this), total);
+    }
+
     // withdraw() and withdrawBatch() is called when a user buys an escrowed asset, a seller cancels an order 
     // and withdraw's their escrowed asset, or a buyer's order is filled and claims the escrowed asset.
     function withdraw(

--- a/contracts/exchange/interfaces/IErc20Escrow.sol
+++ b/contracts/exchange/interfaces/IErc20Escrow.sol
@@ -20,6 +20,8 @@ interface IErc20Escrow {
     function depositBatch(address _token, uint256[] memory _orderIds, address _sender, uint256[] memory _amounts) external;
 
     function withdraw(uint256 _orderId, address _user, uint256 _amount) external;
+
+    function withdrawBatch(uint256[] calldata _orderIds, address _receiver, uint256[] calldata _amounts) external;
     
     function transferRoyalty(address _token, address _sender, address _owner, uint256 _amount) external;
 

--- a/contracts/exchange/interfaces/INftEscrow.sol
+++ b/contracts/exchange/interfaces/INftEscrow.sol
@@ -18,6 +18,13 @@ interface INftEscrow {
         LibOrder.AssetData memory _assetData
     ) external;
 
+    function depositBatch(
+        uint256[] calldata _orderIds,
+        address _sender,
+        uint256[] calldata _amounts,
+        LibOrder.AssetData memory _assetData
+    ) external;
+
     function withdraw(uint256 orderId, address _receiver, uint256 amount) external;
 
     function withdrawBatch(uint256[] memory orderIds, address _receiver, uint256[] memory amounts) external;

--- a/test/exchange/Erc20EscrowTests.js
+++ b/test/exchange/Erc20EscrowTests.js
@@ -96,7 +96,7 @@ describe('ERC20 Escrow Contract tests', () => {
             expect(await rawrToken.balanceOf(escrow.address)).to.equal(tokenAmount);
         });
 
-        it('Deposit multiple batches of Rawr tokens', async () => {
+        it('Deposit multiple orders of Rawr tokens', async () => {
             await setup();
     
             // Allow rawr tokens to be escrowed
@@ -132,7 +132,7 @@ describe('ERC20 Escrow Contract tests', () => {
             expect(await rawrToken.balanceOf(playerAddress.address)).to.equal(ethers.BigNumber.from(20000).mul(_1e18));
         });
 
-        it('Withdraw multiple batches of Rawr tokens', async () => {
+        it('Withdraw multiple orders of Rawr tokens', async () => {
             await setup();
     
             // Allow rawr tokens to be escrowed

--- a/test/exchange/Erc20EscrowTests.js
+++ b/test/exchange/Erc20EscrowTests.js
@@ -52,7 +52,7 @@ describe('ERC20 Escrow Contract tests', () => {
     
         it('Supports the Erc20Escrow Interface', async () => {
             // IErc20Escrow Interface
-            expect(await escrow.supportsInterface("0x3b05caed")).to.equal(true);
+            expect(await escrow.supportsInterface("0x59a8d60b")).to.equal(true);
 
             // IEscrowBase Interface
             expect(await escrow.supportsInterface("0xc7aacb62")).to.equal(true);
@@ -131,6 +131,31 @@ describe('ERC20 Escrow Contract tests', () => {
             expect(await rawrToken.balanceOf(escrow.address)).to.equal(0);
             expect(await rawrToken.balanceOf(playerAddress.address)).to.equal(ethers.BigNumber.from(20000).mul(_1e18));
         });
+
+        it('Withdraw multiple batches of Rawr tokens', async () => {
+            await setup();
+    
+            // Allow rawr tokens to be escrowed
+            var tokenAmount = ethers.BigNumber.from(10000).mul(_1e18);
+            var tokenAmount2 = ethers.BigNumber.from(10000).mul(_1e18);
+            await rawrToken.connect(playerAddress).approve(escrow.address, ethers.BigNumber.from(20000).mul(_1e18));
+            
+            await escrow.connect(executionManagerAddress).depositBatch(rawrToken.address, [0, 1], playerAddress.address, [tokenAmount, tokenAmount2]);
+
+            // playerAddress should have zero tokens left
+            expect(await rawrToken.balanceOf(playerAddress.address)).to.equal(0);
+    
+            // After moving assets to the escrow
+            expect(await rawrToken.balanceOf(escrow.address)).to.equal(ethers.BigNumber.from(20000).mul(_1e18));
+    
+            await escrow.connect(executionManagerAddress).withdrawBatch([0, 1], playerAddress.address, [tokenAmount, tokenAmount2]);
+    
+            // check escrowed tokens by order (1)
+            expect(await escrow.escrowedTokensByOrder(0)).to.equal(0);
+            expect(await escrow.escrowedTokensByOrder(1)).to.equal(0);
+            expect(await rawrToken.balanceOf(escrow.address)).to.equal(0);
+            expect(await rawrToken.balanceOf(playerAddress.address)).to.equal(ethers.BigNumber.from(20000).mul(_1e18));
+        });
         
         it('Withdraw 10000 RAWR tokens from player address in 2 transactions', async () => {
             await setup();
@@ -154,12 +179,14 @@ describe('ERC20 Escrow Contract tests', () => {
     
             // Allow rawr tokens to be escrowed
             var tokenAmount = ethers.BigNumber.from(5000).mul(_1e18);
-            await rawrToken.connect(playerAddress).approve(escrow.address, tokenAmount);
-            await escrow.connect(executionManagerAddress).deposit(rawrToken.address, 1, playerAddress.address, tokenAmount);
+            await rawrToken.connect(playerAddress).approve(escrow.address, ethers.BigNumber.from(10000).mul(_1e18));
+            await escrow.connect(executionManagerAddress).depositBatch(rawrToken.address, [0, 1], playerAddress.address, [tokenAmount, tokenAmount]);
     
-            await expect(escrow.connect(executionManagerAddress).withdraw(1, playerAddress, web3.utils.toWei('10000', 'ether'))).to.be.reverted;
+            await expect(escrow.connect(executionManagerAddress).withdraw(1, playerAddress.address, web3.utils.toWei('10000', 'ether'))).to.be.reverted;
+            await expect(escrow.connect(executionManagerAddress).withdrawBatch([0, 1], playerAddress.address, [web3.utils.toWei('4000', 'ether'), web3.utils.toWei('10000', 'ether')])).to.be.reverted;
 
-            // check escrowed tokens by order (1)
+            // check escrowed tokens by order (0) and (1)
+            expect(await escrow.escrowedTokensByOrder(0)).to.equal(tokenAmount);
             expect(await escrow.escrowedTokensByOrder(1)).to.equal(tokenAmount);
         });
     });

--- a/test/exchange/NftEscrowTests.js
+++ b/test/exchange/NftEscrowTests.js
@@ -71,7 +71,7 @@ describe('NFT Escrow Contract', () => {
     
         it('Supports the NftEscrow Interface', async () => {
             // INftEscrow Interface
-            expect(await escrow.supportsInterface("0x06265fe7")).to.equal(true);
+            expect(await escrow.supportsInterface("0xbe67b45c")).to.equal(true);
             
             // IERC721ReceiverUpgradeable Interface
             expect(await escrow.supportsInterface("0x150b7a02")).to.equal(true);
@@ -120,6 +120,25 @@ describe('NFT Escrow Contract', () => {
             var internalAssetData = await escrow.escrowedAsset(1);
             expect(internalAssetData[0]).to.equal(assetData[0]);
             expect(internalAssetData[1]).to.equal(assetData[1]);
+        });
+
+        it('Depositing Asset Batch', async () => {
+            await createContentContract();
+    
+            await escrow.connect(executionManagerAddress).depositBatch([0, 1], playerAddress.address, [5, 1], assetData);
+            
+            expect(await escrow.escrowedAmounts(0)).to.equal(5);
+            expect(await escrow.escrowedAmounts(1)).to.equal(1);
+            expect(await content.balanceOf(escrow.address, 0)).to.equal(6);
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(4);
+            
+            var internalAssetData = await escrow.escrowedAsset(0);
+            expect(internalAssetData[0]).to.equal(assetData[0]);
+            expect(internalAssetData[1]).to.equal(assetData[1]);
+
+            var internalAssetData2 = await escrow.escrowedAsset(1);
+            expect(internalAssetData2[0]).to.equal(assetData[0]);
+            expect(internalAssetData2[1]).to.equal(assetData[1]);
         });
 
         it('Withdraw Asset', async () => {


### PR DESCRIPTION
In this PR:
- I added a withdrawBatch function in Erc20Escrow.sol and a depositBatch function in NftEscrow.sol, the purpose of this is to transfer all the assets and tokens to and from escrow only once, instead of once each for multiple order ids in a fillBuyOrder transaction. This change increases the cost of a transaction with a single order id by 2.2k gas but decreases the cost of a fillBuyOrder transaction with multiple order Ids by 31.8k less gas than it originally cost for each additional order Id.
- I also added tests for the new functions.