### PR TITLE
update withdrawBatch function

### DIFF
--- a/contracts/exchange/interfaces/INftEscrow.sol
+++ b/contracts/exchange/interfaces/INftEscrow.sol
@@ -27,6 +27,6 @@ interface INftEscrow {
 
     function withdraw(uint256 orderId, address _receiver, uint256 amount) external;
 
-    function withdrawBatch(uint256[] memory orderIds, address _receiver, uint256[] memory amounts) external;
+    function withdrawBatch(uint256[] calldata _orderIds, address _receiver, uint256[] calldata _amounts) external;
 
 }

--- a/test/exchange/NftEscrowTests.js
+++ b/test/exchange/NftEscrowTests.js
@@ -169,11 +169,18 @@ describe('NFT Escrow Contract', () => {
             await escrow.connect(executionManagerAddress).deposit(1, playerAddress.address, 1, assetData);
             await escrow.connect(executionManagerAddress).deposit(2, playerAddress.address, 3, assetData);
             await escrow.connect(executionManagerAddress).deposit(3, playerAddress.address, 2, assetData);
+
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(4);
+            expect(await escrow.escrowedAmounts(1)).to.equal(1);
+            expect(await escrow.escrowedAmounts(2)).to.equal(3);
+            expect(await escrow.escrowedAmounts(3)).to.equal(2);
             
             var orders = [1,2,3];
             var amounts = [1,3,1];
             await escrow.connect(executionManagerAddress).withdrawBatch(orders, playerAddress.address, amounts);
-    
+            
+            expect(await content.balanceOf(playerAddress.address, 0)).to.equal(9);
+            expect(await escrow.escrowedAmounts(1)).to.equal(0);
             expect(await escrow.escrowedAmounts(2)).to.equal(0);
             expect(await escrow.escrowedAmounts(3)).to.equal(1);
         });


### PR DESCRIPTION
In this PR:
-I updated the withdrawBatch function in NftEscrow.sol so that it only sends one transfer function for multiple orderIds. For single order transactions of fillSellOrder, this is cheaper by 875 gas, likely due to the change of storage of the _orderIds and _amounts from memory to calldata. For each additional orderId, the transaction cost 8.6k less than it originally would have cost.