### PR TITLE
combine fillSellOrder and fillBuyOrder

### DIFF
--- a/contracts/exchange/Orderbook.sol
+++ b/contracts/exchange/Orderbook.sol
@@ -92,15 +92,14 @@ contract Orderbook is IOrderbook, ManagerBase {
     }
 
     function verifyAllOrdersData(
-        uint256[] memory _orderIds,
-        bool _isBuyOrder
+        uint256[] memory _orderIds
     ) external view override onlyOwner returns (bool) {
         LibOrder.Order memory firstOrder = orders[_orderIds[0]];
         for (uint256 i = 0; i < _orderIds.length; ++i) {
             if (orders[_orderIds[i]].asset.contentAddress != firstOrder.asset.contentAddress || 
                 orders[_orderIds[i]].asset.tokenId != firstOrder.asset.tokenId ||
                 orders[_orderIds[i]].token != firstOrder.token ||
-                orders[_orderIds[i]].isBuyOrder != _isBuyOrder) {
+                orders[_orderIds[i]].isBuyOrder != firstOrder.isBuyOrder) {
                 return false;
             }
         }

--- a/contracts/exchange/interfaces/IExchange.sol
+++ b/contracts/exchange/interfaces/IExchange.sol
@@ -18,15 +18,9 @@ interface IExchange {
     /******** Mutative Functions ********/
     function placeOrder(LibOrder.OrderInput memory _order) external; 
     
-    function fillBuyOrder(
+    function fillOrderBatch(
         uint256[] memory _orderIds,
-        uint256 amountToSell,
-        uint256 maxSpend
-    ) external;
-
-    function fillSellOrder(
-        uint256[] memory _orderIds,
-        uint256 amountToBuy,
+        uint256 amountToFill,
         uint256 maxSpend
     ) external;
 

--- a/contracts/exchange/interfaces/IOrderbook.sol
+++ b/contracts/exchange/interfaces/IOrderbook.sol
@@ -13,10 +13,7 @@ interface IOrderbook {
         uint256[] memory _orderIds
     ) external view returns (bool);
 
-    function verifyAllOrdersData(
-        uint256[] memory _orderIds,
-        bool _isBuyOrder
-    ) external view returns (bool);
+    function verifyAllOrdersData(uint256[] memory _orderIds) external view returns (bool);
 
     function verifyOrderOwners(
         uint256[] memory _orderIds,

--- a/test/exchange/ExchangeTests.js
+++ b/test/exchange/ExchangeTests.js
@@ -132,7 +132,7 @@ describe('Exchange Contract', () => {
 
     it('Supports the Exchange Interface', async () => {
         // IExchange Interface
-        expect(await exchange.supportsInterface("0x581b76ff")).to.equal(true);
+        expect(await exchange.supportsInterface("0x28b3c9fb")).to.equal(true);
     });
   });
 
@@ -255,7 +255,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
 
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // platform has 30 basis points and creator has 200 basis points from royalties so player2Address should only have
@@ -288,7 +288,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(1000).mul(_1e18));
 
-      expect(await exchange.connect(player2Address).fillSellOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // Player 2 originally has 10, but after buying 1 more, he should have 11
@@ -335,7 +335,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
 
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId, order2Id], 10, ethers.BigNumber.from(1000).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([orderId, order2Id], 10, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // platform has 30 basis points and creator has 200 basis points from royalties so player2Address should only have
@@ -392,7 +392,7 @@ describe('Exchange Contract', () => {
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(400).mul(_1e18));
 
       // Player 2 buys 4 items from the 2 orders
-      expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 4, ethers.BigNumber.from(400).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([order1Id, order2Id], 4, ethers.BigNumber.from(400).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
         .withArgs(player2Address.address, [order1Id, order2Id], [2, 2], [content.address, 0], rawrToken.address, 4, ethers.BigNumber.from(400).mul(_1e18));
 
@@ -444,12 +444,12 @@ describe('Exchange Contract', () => {
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(400).mul(_1e18));
 
       // Fill Order 1 first
-      expect(await exchange.connect(player2Address).fillSellOrder([order1Id], 2, ethers.BigNumber.from(100).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([order1Id], 2, ethers.BigNumber.from(100).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
         .withArgs(player2Address.address, [order1Id], [1], [content.address, 0], rawrToken.address, 1, ethers.BigNumber.from(100).mul(_1e18));
 
       // // Player 2 buys 2 items from the 2 orders, ignoring order
-      expect(await exchange.connect(player2Address).fillSellOrder([order1Id, order2Id], 3, ethers.BigNumber.from(300).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([order1Id, order2Id], 3, ethers.BigNumber.from(300).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled')
         .withArgs(player2Address.address, [order1Id, order2Id], [0, 3], [content.address, 0], rawrToken.address, 3, ethers.BigNumber.from(300).mul(_1e18));
 
@@ -490,7 +490,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the sell order by buying the asset and sending payment
       await rawrToken.connect(player2Address).approve(await exchange.tokenEscrow(), ethers.BigNumber.from(1000).mul(_1e18));
 
-      expect(await exchange.connect(player2Address).fillSellOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // Player 2 originally has 10, but after buying 1 more, he should have 11
@@ -531,7 +531,7 @@ describe('Exchange Contract', () => {
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
 
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       // Claim player 1's purchased asset
@@ -565,7 +565,7 @@ describe('Exchange Contract', () => {
 
       // player 2 fills the buy order by selling the asset and receiving payment minus royalties
       await content.connect(player2Address).setApprovalForAll(await exchange.nftsEscrow(), true);
-      expect(await exchange.connect(player2Address).fillBuyOrder([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
+      expect(await exchange.connect(player2Address).fillOrderBatch([orderId], 1, ethers.BigNumber.from(1000).mul(_1e18)))
         .to.emit(exchange, 'OrdersFilled');
 
       expect(await rawrToken.balanceOf(player2Address.address)).to.equal(ethers.BigNumber.from(10977).mul(_1e18));

--- a/test/exchange/OrderbookTests.js
+++ b/test/exchange/OrderbookTests.js
@@ -59,9 +59,9 @@ describe('Orderbook Contract tests', () => {
       expect(orderbook.address).not.equal(ethers.constants.AddressZero);
     });
 
-    it('Supports the Address resolver Interface', async () => {
+    it('Supports the Orderbook Interface', async () => {
       // IOrderbook Interface
-      expect(await orderbook.supportsInterface("0x2a24311c")).to.equal(true);
+      expect(await orderbook.supportsInterface("0x8af5cda4")).to.equal(true);
     });
   });
 
@@ -190,13 +190,50 @@ describe('Orderbook Contract tests', () => {
     });
 
     it('Verifies orders are of the same asset', async () => {
+      orderData4 = [
+        [contentAddress.address, 2],
+        creatorAddress.address,
+        rawrTokenAddress.address,
+        ethers.BigNumber.from(2000).mul(_1e18),
+        2,
+        false
+      ];
+      orderData5 = [
+        [contentAddress.address, 2],
+        creatorAddress.address,
+        rawrTokenAddress.address,
+        ethers.BigNumber.from(3000).mul(_1e18),
+        3,
+        false
+      ];
+      
       id = await orderbook.ordersLength();
       await orderbook.placeOrder(orderData1);
+      id2 = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData2);
+      id3 = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData3);
+      id4 = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData4);
+      id5 = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData5);
+
+      expect(await orderbook.verifyOrdersExist([id, id3])).is.equal(true);
+      expect(await orderbook.verifyOrdersExist([id2, id4, id5])).is.equal(true);
+      expect(await orderbook.verifyAllOrdersData([id, id3])).is.equal(true);
+      expect(await orderbook.verifyAllOrdersData([id2, id4, id5])).is.equal(true);
+    });
+
+    it('Invalid Order Data', async () => {      
+      id = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData1);
+      id2 = await orderbook.ordersLength();
+      await orderbook.placeOrder(orderData2);
       id3 = await orderbook.ordersLength();
       await orderbook.placeOrder(orderData3);
 
-      expect(await orderbook.verifyOrdersExist([id, id3])).is.equal(true);
-      expect(await orderbook.verifyAllOrdersData([id, id3], true)).is.equal(true);
+      expect(await orderbook.verifyOrdersExist([id, id3, id2])).is.equal(true);
+      expect(await orderbook.verifyAllOrdersData([id, id3, id2])).is.equal(false);
     });
   });
 


### PR DESCRIPTION
In this PR:
- I combined fillSellOrder and fillBuyOrder functions in Exchange.sol into fillOrderBatch()
- I modified verifyAllOrdersData to check whether each order matches the isBuyOrder boolean of the first orderId.